### PR TITLE
fix: use Node.js 22 by default

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -37,6 +37,7 @@ on:
       node-version:
         required: false
         type: string
+        default: 22.20.0
       strict:
         required: false
         type: boolean


### PR DESCRIPTION
Now Node.js 20 is used by default.
Then old `renovate-config-validator` is used, which causes the validation error.